### PR TITLE
fix: Always build debug python bindings

### DIFF
--- a/vars/dragon_nightly.groovy
+++ b/vars/dragon_nightly.groovy
@@ -115,6 +115,14 @@ cd /scratch
 cp -r /home/msk_jenkins/dragon/ dragon/
 source dragon/bin/setup.sh
 
+# Always build a set of debug python bindings to be used in supporting scripts in tests, unless
+# we are a debug build anyway
+if [ ${build} != debug ]; then
+  dragon select ChimeraTK-DeviceAccess-PythonBindings
+  dragon build || true
+  dragon select --all
+fi
+  
 if [ ${build} == tag ]; then
   dragon update --greatest-tag --orphan-on-failure
 fi


### PR DESCRIPTION
So they can be used in test scripts etc. where they are not subject of
the test, but just a helper
