### PR TITLE
fix: Also always build ApplicationCore debug

### DIFF
--- a/vars/dragon_nightly.groovy
+++ b/vars/dragon_nightly.groovy
@@ -117,8 +117,11 @@ source dragon/bin/setup.sh
 
 # Always build a set of debug python bindings to be used in supporting scripts in tests, unless
 # we are a debug build anyway
+# Same for the ApplicationCore python modules
 if [ ${build} != debug ]; then
   dragon select ChimeraTK-DeviceAccess-PythonBindings
+  dragon build || true
+  dragon select ChimeraTK-ApplicationCore
   dragon build || true
   dragon select --all
 fi


### PR DESCRIPTION
So working python bindings are available all the time
